### PR TITLE
Added document title to `/login` and `/signup` pages.

### DIFF
--- a/src/root.tsx
+++ b/src/root.tsx
@@ -44,7 +44,6 @@ export default component$(() => {
         />
         <meta name="twitter:image" content="Image URL Here" />
 
-        <title>qwik-x | Social Media web app</title>
         <meta
           name="description"
           content="Social media web app like Twitter build with Qwikcity"

--- a/src/routes/(auth)/login/index.tsx
+++ b/src/routes/(auth)/login/index.tsx
@@ -1,4 +1,5 @@
 import { component$ } from "@builder.io/qwik";
+import type { DocumentHead } from "@builder.io/qwik-city";
 
 import { LogoIcon } from "~/icons/logo";
 import { Form, Link, routeAction$, z, zod$ } from "@builder.io/qwik-city";
@@ -68,3 +69,7 @@ export default component$(() => {
     </div>
   );
 });
+
+export const head: DocumentHead = {
+  title: "Login | Qwik City 📚 Qwik Documentation"
+};

--- a/src/routes/(auth)/signup/index.tsx
+++ b/src/routes/(auth)/signup/index.tsx
@@ -5,6 +5,7 @@ import { TextInput } from "~/components/ui/text-input";
 import { Button } from "~/components/ui/button";
 import { handleSignup } from "~/utils/auth";
 import { Alert } from "~/components/ui/alert";
+import type { DocumentHead } from "@builder.io/qwik-city";
 
 export const useSignup = routeAction$(
   async (formData, requestEvent) => {
@@ -87,3 +88,7 @@ export default component$(() => {
     </div>
   );
 });
+
+export const head: DocumentHead = {
+    title: "Sign up | Qwik City 📚 Qwik Documentation",
+};


### PR DESCRIPTION
Added title to [login](https://qwik-x.onrender.com/login/) and [signup](https://qwik-x.onrender.com/signup/)  pages using the official method in `qwik-x` framework. I had an conflict while doing it, actually in [main.tsx]() there's a hard coded title was set for all pages, due to which even after using the exporting the head object it was not being updated for all pages. So I removed the link having `<title>` tag. And it is working fine after that... 😊

fixes #32

![image](https://github.com/harshmangalam/qwik-x/assets/121000462/25051e48-af78-4ac7-8373-359e493e8a01)
![image](https://github.com/harshmangalam/qwik-x/assets/121000462/e8939dbe-e76f-4083-bb2d-77b0382e7020)

