### PR TITLE
[FEAT]: Added aria-* in button component

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -44,6 +44,9 @@ export const Button = component$((props: Props) => {
         btnClass,
       ]}
       {...rest}
+        role="button"
+        aria-disabled={loading ? "true" : "false"}
+        aria-busy={loading ? "true" : "false"}
     >
       {loading ? <span class={`loading loading-dots`}></span> : <Slot />}
     </button>


### PR DESCRIPTION
Fixes #51 
Added **possible** and **meaningful** `aria-*` for button component. `aria-` attributes for **loading** and **disabled** has been added depending upon the current loading state of the button.

![image](https://github.com/harshmangalam/qwik-x/assets/121000462/4e04cd44-52ce-451a-af42-6218fa12eb5a)
