### PR TITLE
[FEAT]: Added aria-* attributes to make select component accessible

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -34,10 +34,11 @@ export const Select = component$((props: Props) => {
       <select
         id={id}
         class={["select w-full", { "select-bordered": bordered }, colorScheme]}
+        aria-label={label}
         {...rest}
       >
         {options.map(({ label, value, selected }) => (
-          <option selected={selected} key={value} value={value}>
+          <option selected={selected} key={value} value={value} aria-selected={selected ? "true" : "false"}>
             {label}
           </option>
         ))}


### PR DESCRIPTION
Fixes #54 

Added `aria-label` to `<select>` component and `aria-selected` attribute to `<option>` components.

**I did a lot of research for making HTML `<select>` elements accessible in MDN docs and other websites, but could only found these two attributes to be most relevant here.**

![image](https://github.com/harshmangalam/qwik-x/assets/121000462/6a432fa2-416a-47ee-aebe-5449a6d461ef)
