### PR TITLE
Hide Follow button for Lists created by Current User

### DIFF
--- a/src/components/lists/list-item.tsx
+++ b/src/components/lists/list-item.tsx
@@ -74,10 +74,12 @@ export const ListItem = component$((props: Props) => {
           </div>
         </div>
       </div>
-      {currentUser.value?.id !== owner.id && isFollowing ? (
-        <ListPin listId={id} pinned={hasPinned} />
-      ) : (
-        <Following listId={id} isFollowing={isFollowing} />
+      {(currentUser.value?.id !== owner.id) && (
+        isFollowing ? (
+          <ListPin listId={id} pinned={hasPinned} />
+        ) : (
+          <Following listId={id} isFollowing={isFollowing} />
+        )
       )}
     </li>
   );

--- a/src/routes/(app)/lists/[id]/index.tsx
+++ b/src/routes/(app)/lists/[id]/index.tsx
@@ -5,12 +5,14 @@ import { handleFetchList } from "~/utils/lists";
 import { Avatar } from "~/components/ui/avatar";
 import { WrapBalancer } from "qwikjs-wrap-balancer";
 import { Following } from "./following";
+import { useCurrentUser } from "~/routes/(app)/layout";
 export const useList = routeLoader$(async (requestEvent) => {
   return handleFetchList(requestEvent);
 });
 
 export default component$(() => {
   const listSig = useList();
+  const currentUser = useCurrentUser();
   return (
     <div>
       <PageHeader
@@ -61,10 +63,12 @@ export default component$(() => {
           </Link>
         </div>
         <div class="mt-2">
-          <Following
-            isFollowing={listSig.value.isFollowing}
-            listId={listSig.value.id}
-          />
+          {(currentUser.value?.id !== listSig.value.owner.id) && (
+            <Following
+              isFollowing={listSig.value.isFollowing}
+              listId={listSig.value.id}
+            />
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
Hid the Follow button in:
- Lists page
- Each individual list's page

when the list is created by the Current User.
Closes #45 

---
**Files updated:**
- src/components/lists/list-item.tsx 
- src/routes/(app)/lists/[id]/index.tsx
---
**Testing:**
![test1](https://github.com/harshmangalam/qwik-x/assets/98062538/0b15328d-054e-48b4-9c3f-780bb5d2480b)
![test2](https://github.com/harshmangalam/qwik-x/assets/98062538/c20b993e-ae17-4a4d-953e-bafe94da9eac)
![test3](https://github.com/harshmangalam/qwik-x/assets/98062538/97aaa980-af11-44fc-91aa-1e43cdbe65ef)
![test4](https://github.com/harshmangalam/qwik-x/assets/98062538/d5370cd2-9e53-49ff-b7b6-24d9748698e3)