### PR TITLE
Updated Password Minimum Length Requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DRIZZLE_DATABASE_URL="postgresql://username:password@******.aws.neon.tech/qwikx?sslmode=require"
+JWT_SECRET="itssecret"

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,0 @@
-DRIZZLE_DATABASE_URL="postgresql://username:password@******.aws.neon.tech/qwikx?sslmode=require"
-JWT_SECRET="itssecret"

--- a/src/routes/(auth)/signup/index.tsx
+++ b/src/routes/(auth)/signup/index.tsx
@@ -18,9 +18,13 @@ export const useSignup = routeAction$(
       .nonempty("Enter value for email field")
       .email("Enter valid email address"),
     username: z.string().nonempty("Enter value for username field"),
-    password: z.string().nonempty("Enter value for password field"),
+    password: z
+      .string()
+      .min(8, "Password must be at least 8 characters long")
+      .nonempty("Enter value for password field"),
   })
 );
+
 export default component$(() => {
   const actionSig = useSignup();
   return (


### PR DESCRIPTION
Fixed the issue of Password Minimum Length Requirement Missing on Signup Page. The users are required to enter a password that is at least 8 characters long on the signup page.